### PR TITLE
feat(tickets): improve ticket close message

### DIFF
--- a/apps/bot/package.json
+++ b/apps/bot/package.json
@@ -38,7 +38,6 @@
 		"ipaddr.js": "^2.4.0",
 		"ms": "^2.1.3",
 		"sharp": "^0.34.5",
-
 		"zod": "^4.4.3"
 	},
 	"devDependencies": {

--- a/apps/bot/src/commands/globalModeration/confessionBlacklist.ts
+++ b/apps/bot/src/commands/globalModeration/confessionBlacklist.ts
@@ -1,5 +1,10 @@
 import { Command } from '@sapphire/framework';
-import { MessageFlags, SlashCommandUserOption, SlashCommandStringOption, SlashCommandSubcommandBuilder } from 'discord.js';
+import {
+	MessageFlags,
+	SlashCommandUserOption,
+	SlashCommandStringOption,
+	SlashCommandSubcommandBuilder,
+} from 'discord.js';
 import { addConfessionBlacklist, removeConfessionBlacklist, isConfessionBlacklisted } from '#lib/confessions.js';
 import { emojis } from '#utils/emoji.js';
 
@@ -19,20 +24,28 @@ export class ConfessionBlacklistCommand extends Command {
 					subcommand
 						.setName('add')
 						.setDescription('Blacklist a user from making confessions')
-						.addUserOption((opt: SlashCommandUserOption) => opt.setName('user').setDescription('User to blacklist').setRequired(true))
-						.addStringOption((opt: SlashCommandStringOption) => opt.setName('reason').setDescription('Reason').setMaxLength(512).setRequired(false)),
+						.addUserOption((opt: SlashCommandUserOption) =>
+							opt.setName('user').setDescription('User to blacklist').setRequired(true),
+						)
+						.addStringOption((opt: SlashCommandStringOption) =>
+							opt.setName('reason').setDescription('Reason').setMaxLength(512).setRequired(false),
+						),
 				)
 				.addSubcommand((subcommand: SlashCommandSubcommandBuilder) =>
 					subcommand
 						.setName('remove')
 						.setDescription('Remove a user from the confession blacklist')
-						.addUserOption((opt: SlashCommandUserOption) => opt.setName('user').setDescription('User to unblacklist').setRequired(true)),
+						.addUserOption((opt: SlashCommandUserOption) =>
+							opt.setName('user').setDescription('User to unblacklist').setRequired(true),
+						),
 				)
 				.addSubcommand((subcommand: SlashCommandSubcommandBuilder) =>
 					subcommand
 						.setName('check')
 						.setDescription('Check if a user is blacklisted from confessions')
-						.addUserOption((opt: SlashCommandUserOption) => opt.setName('user').setDescription('User to check').setRequired(true)),
+						.addUserOption((opt: SlashCommandUserOption) =>
+							opt.setName('user').setDescription('User to check').setRequired(true),
+						),
 				),
 		);
 	}

--- a/apps/bot/src/commands/moderation/automod.ts
+++ b/apps/bot/src/commands/moderation/automod.ts
@@ -1,5 +1,13 @@
 import { Command } from '@sapphire/framework';
-import { ActionRowBuilder, ButtonBuilder, ButtonStyle, MessageFlags, PermissionsBitField, SlashCommandSubcommandBuilder, SlashCommandStringOption } from 'discord.js';
+import {
+	ActionRowBuilder,
+	ButtonBuilder,
+	ButtonStyle,
+	MessageFlags,
+	PermissionsBitField,
+	SlashCommandSubcommandBuilder,
+	SlashCommandStringOption,
+} from 'discord.js';
 import { createAutoMod, DuplicateAutoModError, getAutoMod, getAutoMods, removeAutoMod } from '#lib/automod.js';
 import { getQuestUnlimitedPurchaseComponents, LimitError } from '#lib/limits.js';
 import { emojis } from '#utils/emoji.js';
@@ -15,7 +23,7 @@ export class AutoModCommand extends Command {
 			builder
 				.setName('automod')
 				.setDescription('Block words from being said!')
-        .setDefaultMemberPermissions(0)
+				.setDefaultMemberPermissions(0)
 				.addSubcommand((subcommand: SlashCommandSubcommandBuilder) =>
 					subcommand
 						.setName('add')
@@ -29,10 +37,17 @@ export class AutoModCommand extends Command {
 						.setName('remove')
 						.setDescription('Remove words from the automod list.')
 						.addStringOption((option: SlashCommandStringOption) =>
-							option.setName('word').setDescription('The word to remove').setAutocomplete(true).setRequired(true).setMaxLength(36),
+							option
+								.setName('word')
+								.setDescription('The word to remove')
+								.setAutocomplete(true)
+								.setRequired(true)
+								.setMaxLength(36),
 						),
 				)
-				.addSubcommand((subcommand: SlashCommandSubcommandBuilder) => subcommand.setName('list').setDescription('List all blocked words.')),
+				.addSubcommand((subcommand: SlashCommandSubcommandBuilder) =>
+					subcommand.setName('list').setDescription('List all blocked words.'),
+				),
 		);
 	}
 

--- a/apps/bot/src/commands/moderation/autorole/autorole.ts
+++ b/apps/bot/src/commands/moderation/autorole/autorole.ts
@@ -1,5 +1,15 @@
 import { Command } from '@sapphire/framework';
-import { ActionRowBuilder, ButtonBuilder, ButtonStyle, MessageFlags, PermissionFlagsBits, SlashCommandRoleOption, SlashCommandBooleanOption, SlashCommandStringOption, SlashCommandSubcommandBuilder } from 'discord.js';
+import {
+	ActionRowBuilder,
+	ButtonBuilder,
+	ButtonStyle,
+	MessageFlags,
+	PermissionFlagsBits,
+	SlashCommandRoleOption,
+	SlashCommandBooleanOption,
+	SlashCommandStringOption,
+	SlashCommandSubcommandBuilder,
+} from 'discord.js';
 import { createAutoRole, getAutoRole, getAutoRoles, removeAutoRole } from '#lib/autorole.js';
 import { getQuestUnlimitedPurchaseComponents, LimitError } from '#lib/limits.js';
 import { emojis } from '#utils/emoji.js';
@@ -35,10 +45,17 @@ export class AutoRoleCommand extends Command {
 						.setName('remove')
 						.setDescription('Remove an auto role.')
 						.addStringOption((option: SlashCommandStringOption) =>
-							option.setName('role').setDescription('The auto role to remove').setAutocomplete(true).setRequired(true).setMaxLength(36),
+							option
+								.setName('role')
+								.setDescription('The auto role to remove')
+								.setAutocomplete(true)
+								.setRequired(true)
+								.setMaxLength(36),
 						),
 				)
-				.addSubcommand((subcommand: SlashCommandSubcommandBuilder) => subcommand.setName('list').setDescription('List all auto roles.')),
+				.addSubcommand((subcommand: SlashCommandSubcommandBuilder) =>
+					subcommand.setName('list').setDescription('List all auto roles.'),
+				),
 		);
 	}
 

--- a/apps/bot/src/commands/moderation/ban/ban.ts
+++ b/apps/bot/src/commands/moderation/ban/ban.ts
@@ -6,9 +6,9 @@ import {
 	GuildMember,
 	MessageFlags,
 	PermissionsBitField,
-  PermissionFlagsBits,
-  SlashCommandUserOption,
-  SlashCommandStringOption,
+	PermissionFlagsBits,
+	SlashCommandUserOption,
+	SlashCommandStringOption,
 } from 'discord.js';
 import ms, { type StringValue } from 'ms';
 import { applyBan, createBan } from '#lib/bans.js';
@@ -24,11 +24,13 @@ export class BanCommand extends Command {
 			builder
 				.setName('ban')
 				.setDescription('Ban someone from the discord server.')
-        .setDefaultMemberPermissions(PermissionFlagsBits.BanMembers)
+				.setDefaultMemberPermissions(PermissionFlagsBits.BanMembers)
 				.addUserOption((option: SlashCommandUserOption) =>
 					option.setName('member').setDescription('Select a member to ban').setRequired(true),
 				)
-				.addStringOption((option: SlashCommandStringOption) => option.setName('reason').setDescription('Provide a reason for their ban').setMaxLength(512))
+				.addStringOption((option: SlashCommandStringOption) =>
+					option.setName('reason').setDescription('Provide a reason for their ban').setMaxLength(512),
+				)
 				.addStringOption((option: SlashCommandStringOption) =>
 					option.setName('duration').setDescription('Provide a duration for their ban (if needed)').setMaxLength(20),
 				),

--- a/apps/bot/src/commands/moderation/ban/unban.ts
+++ b/apps/bot/src/commands/moderation/ban/unban.ts
@@ -6,8 +6,8 @@ import {
 	GuildMember,
 	MessageFlags,
 	PermissionsBitField,
-  PermissionFlagsBits,
-  SlashCommandStringOption
+	PermissionFlagsBits,
+	SlashCommandStringOption,
 } from 'discord.js';
 import { getBan, removeBan } from '#lib/bans.js';
 import { emojis } from '#utils/emoji.js';
@@ -22,11 +22,11 @@ export class UnbanCommand extends Command {
 			builder
 				.setName('unban')
 				.setDescription('Unban someone from the discord server.')
-        .setDefaultMemberPermissions(PermissionFlagsBits.BanMembers)
-				.addUserOption((option) =>
-					option.setName('member').setDescription('The member to unban').setRequired(true),
-				)
-				.addStringOption((option: SlashCommandStringOption) => option.setName('reason').setDescription('Provide a reason for their unban').setMaxLength(512)),
+				.setDefaultMemberPermissions(PermissionFlagsBits.BanMembers)
+				.addUserOption((option) => option.setName('member').setDescription('The member to unban').setRequired(true))
+				.addStringOption((option: SlashCommandStringOption) =>
+					option.setName('reason').setDescription('Provide a reason for their unban').setMaxLength(512),
+				),
 		);
 	}
 

--- a/apps/bot/src/commands/moderation/kick.ts
+++ b/apps/bot/src/commands/moderation/kick.ts
@@ -6,9 +6,9 @@ import {
 	GuildMember,
 	MessageFlags,
 	PermissionsBitField,
-  PermissionFlagsBits,
-  SlashCommandUserOption,
-  SlashCommandStringOption,
+	PermissionFlagsBits,
+	SlashCommandUserOption,
+	SlashCommandStringOption,
 } from 'discord.js';
 import { emojis } from '#utils/emoji.js';
 
@@ -22,11 +22,13 @@ export class KickCommand extends Command {
 			builder
 				.setName('kick')
 				.setDescription('Kick someone from the discord server.')
-        .setDefaultMemberPermissions(PermissionFlagsBits.KickMembers)
+				.setDefaultMemberPermissions(PermissionFlagsBits.KickMembers)
 				.addUserOption((option: SlashCommandUserOption) =>
 					option.setName('member').setDescription('Select a member to kick').setRequired(true),
 				)
-				.addStringOption((option: SlashCommandStringOption) => option.setName('reason').setDescription('Provide a reason for their kick').setMaxLength(512)),
+				.addStringOption((option: SlashCommandStringOption) =>
+					option.setName('reason').setDescription('Provide a reason for their kick').setMaxLength(512),
+				),
 		);
 	}
 

--- a/apps/bot/src/commands/moderation/mute/mute.ts
+++ b/apps/bot/src/commands/moderation/mute/mute.ts
@@ -6,9 +6,9 @@ import {
 	GuildMember,
 	MessageFlags,
 	PermissionsBitField,
-  PermissionFlagsBits,
-  SlashCommandUserOption,
-  SlashCommandStringOption,
+	PermissionFlagsBits,
+	SlashCommandUserOption,
+	SlashCommandStringOption,
 } from 'discord.js';
 import ms, { type StringValue } from 'ms';
 import { createMute, enforceMute } from '#lib/mutes.js';
@@ -24,12 +24,16 @@ export class MuteCommand extends Command {
 			builder
 				.setName('mute')
 				.setDescription('Mute someone in the discord server.')
-        .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers)
+				.setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers)
 				.addUserOption((option: SlashCommandUserOption) =>
 					option.setName('member').setDescription('Select a member to mute').setRequired(true),
 				)
-				.addStringOption((option: SlashCommandStringOption) => option.setName('duration').setDescription('Specify a duration for the mute').setMaxLength(20))
-				.addStringOption((option: SlashCommandStringOption) => option.setName('reason').setDescription('Provide a reason for their mute').setMaxLength(512)),
+				.addStringOption((option: SlashCommandStringOption) =>
+					option.setName('duration').setDescription('Specify a duration for the mute').setMaxLength(20),
+				)
+				.addStringOption((option: SlashCommandStringOption) =>
+					option.setName('reason').setDescription('Provide a reason for their mute').setMaxLength(512),
+				),
 		);
 	}
 

--- a/apps/bot/src/commands/moderation/mute/unmute.ts
+++ b/apps/bot/src/commands/moderation/mute/unmute.ts
@@ -6,9 +6,9 @@ import {
 	GuildMember,
 	MessageFlags,
 	PermissionsBitField,
-  PermissionFlagsBits,
-  SlashCommandUserOption,
-  SlashCommandStringOption
+	PermissionFlagsBits,
+	SlashCommandUserOption,
+	SlashCommandStringOption,
 } from 'discord.js';
 import { removeMute } from '#lib/mutes.js';
 import { emojis } from '#utils/emoji.js';
@@ -23,11 +23,13 @@ export class UnmuteCommand extends Command {
 			builder
 				.setName('unmute')
 				.setDescription('Unmute someone in the discord server.')
-        .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers)
+				.setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers)
 				.addUserOption((option: SlashCommandUserOption) =>
 					option.setName('member').setDescription('Select a member to unmute').setRequired(true),
 				)
-				.addStringOption((option: SlashCommandStringOption) => option.setName('reason').setDescription('Provide a reason for their unmute').setMaxLength(512)),
+				.addStringOption((option: SlashCommandStringOption) =>
+					option.setName('reason').setDescription('Provide a reason for their unmute').setMaxLength(512),
+				),
 		);
 	}
 

--- a/apps/bot/src/commands/moderation/nick.ts
+++ b/apps/bot/src/commands/moderation/nick.ts
@@ -1,5 +1,12 @@
 import { Command } from '@sapphire/framework';
-import { GuildMember, MessageFlags, PermissionsBitField, SlashCommandStringOption, SlashCommandUserOption, PermissionFlagsBits } from 'discord.js';
+import {
+	GuildMember,
+	MessageFlags,
+	PermissionsBitField,
+	SlashCommandStringOption,
+	SlashCommandUserOption,
+	PermissionFlagsBits,
+} from 'discord.js';
 import { emojis } from '#utils/emoji.js';
 
 export class NickCommand extends Command {
@@ -12,11 +19,13 @@ export class NickCommand extends Command {
 			builder
 				.setName('nick')
 				.setDescription("Change a member's nickname.")
-        .setDefaultMemberPermissions(PermissionFlagsBits.ManageNicknames)
+				.setDefaultMemberPermissions(PermissionFlagsBits.ManageNicknames)
 				.addUserOption((option: SlashCommandUserOption) =>
 					option.setName('member').setDescription('Select a member to change their nickname').setRequired(true),
 				)
-				.addStringOption((option: SlashCommandStringOption) => option.setName('nickname').setDescription('Nickname (leave empty to reset)').setMaxLength(32)),
+				.addStringOption((option: SlashCommandStringOption) =>
+					option.setName('nickname').setDescription('Nickname (leave empty to reset)').setMaxLength(32),
+				),
 		);
 	}
 

--- a/apps/bot/src/commands/moderation/purge.ts
+++ b/apps/bot/src/commands/moderation/purge.ts
@@ -43,7 +43,11 @@ export class PurgeCommand extends Command {
 			return;
 		}
 
-		if (!member || !('permissions' in member) || !channel.permissionsFor(member)?.has(PermissionsBitField.Flags.ManageMessages)) {
+		if (
+			!member ||
+			!('permissions' in member) ||
+			!channel.permissionsFor(member)?.has(PermissionsBitField.Flags.ManageMessages)
+		) {
 			await interaction.reply({
 				content: `${emojis.rightArrow2} You do not have permission to manage messages.`,
 				flags: MessageFlags.Ephemeral,

--- a/apps/bot/src/commands/moderation/slowmode.ts
+++ b/apps/bot/src/commands/moderation/slowmode.ts
@@ -15,9 +15,12 @@ export class SlowmodeCommand extends Command {
 			builder
 				.setName('slowmode')
 				.setDescription('Set or clear the slowmode for the current channel.')
-        .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels)
+				.setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels)
 				.addStringOption((option: SlashCommandStringOption) =>
-					option.setName('duration').setDescription('Provide a duration for slowmode, or leave blank to remove it').setMaxLength(20),
+					option
+						.setName('duration')
+						.setDescription('Provide a duration for slowmode, or leave blank to remove it')
+						.setMaxLength(20),
 				),
 		);
 	}
@@ -42,7 +45,11 @@ export class SlowmodeCommand extends Command {
 			return;
 		}
 
-		if (!member || !('permissions' in member) || !channel.permissionsFor(member)?.has(PermissionsBitField.Flags.ManageChannels)) {
+		if (
+			!member ||
+			!('permissions' in member) ||
+			!channel.permissionsFor(member)?.has(PermissionsBitField.Flags.ManageChannels)
+		) {
 			await interaction.reply({
 				content: `${emojis.rightArrow2} You do not have permission to manage channels.`,
 				flags: MessageFlags.Ephemeral,

--- a/apps/bot/src/commands/moderation/warn/unwarn.ts
+++ b/apps/bot/src/commands/moderation/warn/unwarn.ts
@@ -5,8 +5,8 @@ import {
 	ButtonStyle,
 	GuildMember,
 	MessageFlags,
-  SlashCommandStringOption,
-  PermissionFlagsBits,
+	SlashCommandStringOption,
+	PermissionFlagsBits,
 	PermissionsBitField,
 } from 'discord.js';
 import { getWarn, removeWarn } from '#lib/warns.js';
@@ -22,7 +22,7 @@ export class UnwarnCommand extends Command {
 			builder
 				.setName('unwarn')
 				.setDescription('Unwarn someone in the discord server.')
-        .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers)
+				.setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers)
 				.addStringOption((option: SlashCommandStringOption) =>
 					option.setName('id').setDescription('The ID of the warn to remove').setRequired(true).setMaxLength(36),
 				)

--- a/apps/bot/src/commands/moderation/warn/warn.ts
+++ b/apps/bot/src/commands/moderation/warn/warn.ts
@@ -7,7 +7,7 @@ import {
 	EmbedBuilder,
 	GuildMember,
 	MessageFlags,
-  PermissionFlagsBits,
+	PermissionFlagsBits,
 	PermissionsBitField,
 } from 'discord.js';
 import ms, { type StringValue } from 'ms';
@@ -25,12 +25,14 @@ export class WarnCommand extends Command {
 			builder
 				.setName('warn')
 				.setDescription('Warn someone in the discord server.')
-        .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers)
-				.addUserOption((option) =>
-					option.setName('member').setDescription('Select a member to warn').setRequired(true),
+				.setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers)
+				.addUserOption((option) => option.setName('member').setDescription('Select a member to warn').setRequired(true))
+				.addStringOption((option) =>
+					option.setName('reason').setDescription('Provide a reason for their warn').setMaxLength(512),
 				)
-				.addStringOption((option) => option.setName('reason').setDescription('Provide a reason for their warn').setMaxLength(512))
-				.addStringOption((option) => option.setName('duration').setDescription('Specify a duration for the warn').setMaxLength(20)),
+				.addStringOption((option) =>
+					option.setName('duration').setDescription('Specify a duration for the warn').setMaxLength(20),
+				),
 		);
 	}
 

--- a/apps/bot/src/commands/moderation/warn/warns.ts
+++ b/apps/bot/src/commands/moderation/warn/warns.ts
@@ -1,5 +1,11 @@
 import { Command } from '@sapphire/framework';
-import { GuildMember, MessageFlags, PermissionFlagsBits, PermissionsBitField, SlashCommandUserOption } from 'discord.js';
+import {
+	GuildMember,
+	MessageFlags,
+	PermissionFlagsBits,
+	PermissionsBitField,
+	SlashCommandUserOption,
+} from 'discord.js';
 import { getWarns } from '#lib/warns.js';
 import { emojis } from '#utils/emoji.js';
 
@@ -13,8 +19,10 @@ export class WarnsCommand extends Command {
 			builder
 				.setName('warns')
 				.setDescription('View (someones) warns.')
-        .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers)
-				.addUserOption((option: SlashCommandUserOption) => option.setName('member').setDescription('Member to view warns of')),
+				.setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers)
+				.addUserOption((option: SlashCommandUserOption) =>
+					option.setName('member').setDescription('Member to view warns of'),
+				),
 		);
 	}
 

--- a/apps/bot/src/commands/ping.ts
+++ b/apps/bot/src/commands/ping.ts
@@ -7,9 +7,7 @@ export class PingCommand extends Command {
 	}
 
 	public override registerApplicationCommands(registry: Command.Registry) {
-		registry.registerChatInputCommand((builder) =>
-			builder.setName('ping').setDescription("Return the bot's latency."),
-		);
+		registry.registerChatInputCommand((builder) => builder.setName('ping').setDescription("Return the bot's latency."));
 	}
 
 	public override async chatInputRun(interaction: Command.ChatInputCommandInteraction) {

--- a/apps/bot/src/commands/utility/fun/confess.ts
+++ b/apps/bot/src/commands/utility/fun/confess.ts
@@ -20,12 +20,10 @@ export class ConfessCommand extends Command {
 		super(context, { ...options, preconditions: ['devMode'] });
 	}
 
-  // I believe this command still needs some touchups
+	// I believe this command still needs some touchups
 
 	public override registerApplicationCommands(_registry: Command.Registry) {
-		_registry.registerChatInputCommand((builder) =>
-			builder.setName('confess').setDescription('Create a confession'),
-		);
+		_registry.registerChatInputCommand((builder) => builder.setName('confess').setDescription('Create a confession'));
 	}
 
 	public override async chatInputRun(interaction: Command.ChatInputCommandInteraction) {

--- a/apps/bot/src/commands/utility/reminder/reminder.ts
+++ b/apps/bot/src/commands/utility/reminder/reminder.ts
@@ -30,7 +30,9 @@ export class ReminderCommand extends Command {
 					subcommand
 						.setName('remove')
 						.setDescription('Cancel a reminder.')
-						.addStringOption((option: SlashCommandStringOption) => option.setName('id').setDescription('The reminder ID').setRequired(true).setMaxLength(36)),
+						.addStringOption((option: SlashCommandStringOption) =>
+							option.setName('id').setDescription('The reminder ID').setRequired(true).setMaxLength(36),
+						),
 				),
 		);
 	}

--- a/apps/bot/src/commands/utility/suggest.ts
+++ b/apps/bot/src/commands/utility/suggest.ts
@@ -1,69 +1,69 @@
 import { Command, BucketScope } from '@sapphire/framework';
-import { emojis } from '#utils/emoji.js'
+import { emojis } from '#utils/emoji.js';
 import { SlashCommandStringOption, MessageFlags } from 'discord.js';
 
 export class SuggestCommand extends Command {
-  public constructor(context: Command.LoaderContext, options: Command.Options) {
-    super(context, { 
-      ...options, 
-      preconditions: ['devMode'],
-      cooldownDelay: 60_000,
-      cooldownLimit: 1,
-      cooldownScope: BucketScope.User,
-    });
-  }
+	public constructor(context: Command.LoaderContext, options: Command.Options) {
+		super(context, {
+			...options,
+			preconditions: ['devMode'],
+			cooldownDelay: 60_000,
+			cooldownLimit: 1,
+			cooldownScope: BucketScope.User,
+		});
+	}
 
-  public override registerApplicationCommands(registry: Command.Registry) {
-    registry.registerChatInputCommand((builder) =>
-      builder
-        .setName('suggest')
-        .setDescription('Suggest a feature for Quest Bot!')
-        .addStringOption((option: SlashCommandStringOption) =>
-          option.setName('suggestion').setDescription('This is what will be sent to us!').setRequired(true)
-        )
-    );
-  }
+	public override registerApplicationCommands(registry: Command.Registry) {
+		registry.registerChatInputCommand((builder) =>
+			builder
+				.setName('suggest')
+				.setDescription('Suggest a feature for Quest Bot!')
+				.addStringOption((option: SlashCommandStringOption) =>
+					option.setName('suggestion').setDescription('This is what will be sent to us!').setRequired(true),
+				),
+		);
+	}
 
-  public override async chatInputRun(interaction: Command.ChatInputCommandInteraction) {
-    const webhook = process.env.SUGGESTIONS_URL ?? ''
-    const message = interaction.options.getString('suggestion');
-    const name = interaction.user.username; 
+	public override async chatInputRun(interaction: Command.ChatInputCommandInteraction) {
+		const webhook = process.env.SUGGESTIONS_URL ?? '';
+		const message = interaction.options.getString('suggestion');
+		const name = interaction.user.username;
 
-    if (!message) {
-      interaction.reply(`${emojis.rightArrow2} Please provide a suggestion!`);
-      return;
-    }
+		if (!message) {
+			interaction.reply(`${emojis.rightArrow2} Please provide a suggestion!`);
+			return;
+		}
 
-    if (!webhook) {
-      interaction.reply(`${emojis.rightArrow2} Suggestions have not been setup yet.`);
-      return;
-    }
-    
-    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+		if (!webhook) {
+			interaction.reply(`${emojis.rightArrow2} Suggestions have not been setup yet.`);
+			return;
+		}
 
-    try {  
-      const response = await fetch(webhook, {
-        method: "POST",
-        body: JSON.stringify({
-          userId: interaction.user.id,
-          username: name,
-          body: message
-        }),
-        headers: {
-          "Content-type": "application/json; charset=UTF-8"
-        }
-      });
+		await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
-      if (response.ok) {
-        await interaction.editReply(`${emojis.rightArrow1} Sent!`)
-        return;
-      } else {
-        await interaction.editReply(`${emojis.rightArrow2} There was an error trying to send your suggestion!`)
-        return;
-      }
-    } catch {
-      await interaction.editReply(`${emojis.rightArrow2} There was an error trying to send your suggestion!`)
-      return;
-    }
-  }
+		try {
+			const response = await fetch(webhook, {
+				method: 'POST',
+				body: JSON.stringify({
+					userId: interaction.user.id,
+					username: name,
+					body: message,
+				}),
+				headers: {
+					'Content-type': 'application/json; charset=UTF-8',
+				},
+			});
+
+			if (response.ok) {
+				await interaction.editReply(`${emojis.rightArrow1} Sent!`);
+				return;
+			} else {
+				await interaction.editReply(`${emojis.rightArrow2} There was an error trying to send your suggestion!`);
+				return;
+			}
+		} catch {
+			await interaction.editReply(`${emojis.rightArrow2} There was an error trying to send your suggestion!`);
+			return;
+		}
+	}
 }

--- a/apps/bot/src/interaction-handlers/ticket/removeTicketHandler.ts
+++ b/apps/bot/src/interaction-handlers/ticket/removeTicketHandler.ts
@@ -1,5 +1,16 @@
 import { InteractionHandler, InteractionHandlerTypes } from '@sapphire/framework';
-import { ActionRowBuilder, ButtonBuilder, ButtonStyle, MessageFlags, ChannelType, AttachmentBuilder } from 'discord.js';
+import {
+	ActionRowBuilder,
+	ButtonBuilder,
+	ButtonStyle,
+	MessageFlags,
+	ChannelType,
+	AttachmentBuilder,
+	ModalBuilder,
+	TextInputBuilder,
+	TextInputStyle,
+	LabelBuilder,
+} from 'discord.js';
 import type { ButtonInteraction, TextChannel } from 'discord.js';
 import { emojis } from '#utils/emoji.js';
 import { getTicketId, removeTicket } from '#lib/tickets.js';
@@ -119,10 +130,51 @@ export class ButtonHandler extends InteractionHandler {
 			return;
 		}
 
-		await interaction.update({
+		const reasonInput = new TextInputBuilder()
+			.setCustomId('ticket-close-reason')
+			.setStyle(TextInputStyle.Paragraph)
+			.setRequired(false)
+			.setMaxLength(1_000);
+
+		const reasonLabel = new LabelBuilder().setLabel('Reason for closing').setTextInputComponent(reasonInput);
+
+		const modal = new ModalBuilder()
+			.setCustomId('close-ticket-modal')
+			.setTitle('Close Ticket')
+			.addLabelComponents(reasonLabel);
+
+		await interaction.showModal(modal);
+
+		const modalSubmit = await interaction
+			.awaitModalSubmit({
+				filter: (modalInteraction) =>
+					modalInteraction.customId === 'close-ticket-modal' && modalInteraction.user.id === interaction.user.id,
+				time: 60_000,
+			})
+			.catch(() => null);
+
+		if (!modalSubmit) return;
+
+		await modalSubmit.reply({
 			content: `${emojis.rightArrow2} Closing ticket...`,
-			components: [],
+			flags: MessageFlags.Ephemeral,
 		});
+
+		const rawReason = modalSubmit.fields.getTextInputValue('ticket-close-reason');
+		const reason = rawReason && rawReason.trim() !== '' ? rawReason.trim() : 'No reason provided';
+
+		if (channel.isTextBased()) {
+			await channel.send({
+				content: [
+					`This ticket will be closed shortly.`,
+					``,
+					`**Closed by:** <@${interaction.user.id}>`,
+					`**Reason:** ${reason}`,
+				].join('\n'),
+			});
+		}
+
+		await new Promise((resolve) => setTimeout(resolve, 5000));
 
 		const ticket = await getTicketId(interaction.guild.id, channel.id);
 
@@ -156,7 +208,7 @@ export class ButtonHandler extends InteractionHandler {
 				await removeTicket(ticket.id);
 			}
 
-			await channel.delete(`Ticket closed by ${interaction.user.tag}.`);
+			await channel.delete(`Ticket closed by ${interaction.user.tag}. Reason: ${reason}`);
 		} catch (err) {
 			console.log(err);
 		}

--- a/apps/bot/src/lib/automod.ts
+++ b/apps/bot/src/lib/automod.ts
@@ -29,7 +29,9 @@ export async function createAutoMod(
 		}
 
 		if (autoModCount >= 250 && hasUnlimitedAccess) {
-			throw new LimitError('A guild with unlimited access can only have up to 250 automod rules. This is to combat abuse.');
+			throw new LimitError(
+				'A guild with unlimited access can only have up to 250 automod rules. This is to combat abuse.',
+			);
 		}
 	}
 

--- a/apps/bot/src/lib/autorole.ts
+++ b/apps/bot/src/lib/autorole.ts
@@ -19,7 +19,9 @@ export async function createAutoRole(
 		}
 
 		if (autoRoleCount >= 250 && hasUnlimitedAccess) {
-			throw new LimitError('A guild with unlimited access can only have up to 250 auto roles. This is to combat abuse.');
+			throw new LimitError(
+				'A guild with unlimited access can only have up to 250 auto roles. This is to combat abuse.',
+			);
 		}
 	}
 

--- a/apps/bot/src/lib/safeFetch.ts
+++ b/apps/bot/src/lib/safeFetch.ts
@@ -7,9 +7,7 @@ const TIMEOUT_MS = 10_000;
 export class SafeFetchError extends Error {}
 
 async function assertSafeHost(hostname: string): Promise<void> {
-	const records = ipaddr.isValid(hostname)
-		? [{ address: hostname }]
-		: await lookup(hostname, { all: true });
+	const records = ipaddr.isValid(hostname) ? [{ address: hostname }] : await lookup(hostname, { all: true });
 
 	if (records.length === 0) {
 		throw new SafeFetchError(`No DNS records for ${hostname}`);
@@ -29,7 +27,11 @@ function validate(url: URL) {
 
 export async function safeFetch(raw: string, init: RequestInit = {}): Promise<Response> {
 	let url: URL;
-	try { url = new URL(raw); } catch { throw new SafeFetchError('Invalid URL.'); }
+	try {
+		url = new URL(raw);
+	} catch {
+		throw new SafeFetchError('Invalid URL.');
+	}
 
 	for (let i = 0; i <= MAX_REDIRECTS; i++) {
 		validate(url);
@@ -38,8 +40,10 @@ export async function safeFetch(raw: string, init: RequestInit = {}): Promise<Re
 		const res = await fetch(url, {
 			...init,
 			redirect: 'manual',
-			signal: AbortSignal.timeout(TIMEOUT_MS)
-		}).catch(() => {throw new SafeFetchError('Request failed.');});
+			signal: AbortSignal.timeout(TIMEOUT_MS),
+		}).catch(() => {
+			throw new SafeFetchError('Request failed.');
+		});
 
 		if (res.status >= 300 && res.status < 400) {
 			const loc = res.headers.get('location');

--- a/apps/bot/src/listeners/messageUpdate.ts
+++ b/apps/bot/src/listeners/messageUpdate.ts
@@ -47,4 +47,3 @@ export class MessageUpdateListener extends Listener {
 		await logEmbed(guild, embed);
 	}
 }
-

--- a/apps/bot/src/listeners/ready.ts
+++ b/apps/bot/src/listeners/ready.ts
@@ -17,7 +17,7 @@ export class ReadyListener extends Listener<typeof Events.ClientReady> {
 
 	public async run(client: Client<true>) {
 		console.log(`Ready! Logged in as ${client.user.tag}`);
-    const status = process.env.STATUS ?? ''
+		const status = process.env.STATUS ?? '';
 
 		client.user.setActivity({
 			name: `${status} | Shard ${client.shard?.ids?.[0] ?? 0}`,


### PR DESCRIPTION
Implements an optional reason input modal when a staff member closes a ticket, sending a cleaner message in the channel before deleting it after 5 seconds.